### PR TITLE
Filter for Robolinho devices only

### DIFF
--- a/pyalko/__init__.py
+++ b/pyalko/__init__.py
@@ -37,7 +37,7 @@ class Alko(AlkoBase):
     async def get_devices(self) -> None:
         """Get Devices."""
         response: ClientResponse = await self._client.get(
-            f"{BASE_URL}?pimInfo=true&thingState=true&accesses=true"
+            f"{BASE_URL}?pimInfo=true&thingState=true&accesses=true&thingCategory=ALKO-ROBOLINHO"
         )
         json = await response.json()
         self._devices = [


### PR DESCRIPTION
At the moment, the AL-KO Home Assistant custom integration only supports Robolinho devices. We should therefore filter for those devices. Otherwise you might have a lot of devices in your list that you can not control as expected.